### PR TITLE
Retry IotHub connection on failure

### DIFF
--- a/SMSEagleIOTBridge/nyss-iot-bridge.service
+++ b/SMSEagleIOTBridge/nyss-iot-bridge.service
@@ -1,11 +1,16 @@
 [Unit]
 Description=This is the service for the iot bridge to azure
-After=multi-user.target
- 
+Wants=network-online.target
+After=network.target network-online.target
+Requires=network-online.target
+
+
 [Service]
 Type=simple
+Restart=always
+RestartSec=10
+ExecStartPre=/bin/sh -c 'until ping -c1 azure.microsoft.com; do sleep 5; done;'
 ExecStart=/usr/bin/python3 /home/pi/smsEagle-iot-hub-handler.py
-Restart=on-abort
- 
+
 [Install]
 WantedBy=multi-user.target

--- a/SMSEagleIOTBridge/nyssIotBridge.py
+++ b/SMSEagleIOTBridge/nyssIotBridge.py
@@ -2,8 +2,10 @@ import os
 import threading
 from six.moves import input
 from azure.iot.device import IoTHubDeviceClient, MethodResponse
+from azure.iot.device.exceptions import ConnectionFailedError
 import json
 import logging
+import time
 
 logger = logging.getLogger("iot-hub-bridge")
 
@@ -34,17 +36,27 @@ def device_method_listener(device_client, methods_to_listen_for):
         method_response = MethodResponse.create_from_method_request(method_request, status, payload)
         device_client.send_method_response(method_response)
 
+def connect(client):
+    print("Connecting to IoT Hub")
+    try:
+        client.connect()
+    except ConnectionFailedError as e:
+        print("Could not connect to IoT Hub")
+        return False
+    else:
+        return True
 
 def init(connection_string, methods):
     if connection_string is "":
         print("Missing connection string!")
         return 0
 
-    print("Starting listening for direct methods of type [{}]...".format(', '.join(methods.keys())))
-
     client = IoTHubDeviceClient.create_from_connection_string(connection_string, websockets=True)
     # connect the client.
-    client.connect()
+    while connect(client) == False:
+        time.sleep(10)
+    
+    print("Starting listening for direct methods of type [{}]...".format(', '.join(methods.keys())))
 
     # Run method listener threads in the background
     device_method_thread = threading.Thread(target=device_method_listener, args=(client, methods))


### PR DESCRIPTION
Very simple reconnect feature in case the SMS Eagle doesn't have internet access on the first attempt.

Not sure about the performance impact or if time.sleep affects other parts of the system as well, but seems to work fine locally without an actual eagle.