### PR TITLE
Update IoT Hub handler script when booting the device

### DIFF
--- a/SMSEagleIOTBridge/Readme_Prepare_Eagle.md
+++ b/SMSEagleIOTBridge/Readme_Prepare_Eagle.md
@@ -136,8 +136,8 @@ The python script is developed in the following repository:
 * https://github.com/nyss-platform-norcross/nyss-sms-gateway
 
 You need the following files:
-* https://github.com/nyss-platform-norcross/nyss-sms-gateway/blob/sms-eagle-iot-connection/SMSEagleIOTBridge/nyssIotBridge.py 
-* https://github.com/nyss-platform-norcross/nyss-sms-gateway/blob/sms-eagle-iot-connection/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
+* https://github.com/nyss-platform-norcross/nyss-sms-gateway/blob/master/SMSEagleIOTBridge/nyssIotBridge.py 
+* https://github.com/nyss-platform-norcross/nyss-sms-gateway/blob/master/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
 
 If the repository does not exist anymore for some reason, you can probably find the files on one of the existing SMSEagles in the folder /home/pi. 
 After you have downloaded them, make sure that the filename is exactly that, and e.g. windows did not "accidentally" add .txt as an extension.
@@ -158,12 +158,12 @@ scp "C:/path on windows to file" root@ipOfEagle:/home/pi
 If you installed Python using what is described in Chapter 1.2.2.1., you can skip step 2.
 
 #### 1. Get the necessary files
-
-The service file is in the same repository as the python script:
+You need the service file as well as the shell script to run before the service starts. The files are in the same repository as the python script:
 - https://github.com/nyss-platform-norcross/nyss-sms-gateway
 
-You need the following file:
-* https://github.com/nyss-platform-norcross/nyss-sms-gateway/blob/sms-eagle-iot-connection/SMSEagleIOTBridge/nyss-iot-bridge.service
+You need the following files:
+* https://github.com/nyss-platform-norcross/nyss-sms-gateway/blob/master/SMSEagleIOTBridge/nyss-iot-bridge.service
+* https://github.com/nyss-platform-norcross/nyss-sms-gateway/blob/master/SMSEagleIOTBridge/nyssIotBridgeBoot.sh
 
 If the repository does not exist anymore for some reason, you can probably find the files on one of the existing SMSEagles in the folder /etc/systemd/system.
 
@@ -194,10 +194,14 @@ Copy the following file to the SMSEagles /etc/systemd/system folder:
 ```
 nyss-iot-bridge.service
 ```
-
+And the following file to the SMSEagles /home/pi folder
+```
+nyssIotBridgeBoot.sh
+```
 Via ssh you can use the following commands as run from your host computer and not the SMSEagle:
 ```
-scp "C:/path on windows to file" root@ipOfEagle:/etc/systemd/system
+scp "C:/path on windows to service file" root@ipOfEagle:/etc/systemd/system
+scp "C:/path on windows to shell script file" root@ipOfEagle:/home/pi
 ```
 
 SSH back to the SMSEagle and set the access rights on the files using the following commands:

--- a/SMSEagleIOTBridge/nyss-iot-bridge.service
+++ b/SMSEagleIOTBridge/nyss-iot-bridge.service
@@ -10,7 +10,7 @@ Type=simple
 Restart=always
 RestartSec=10
 ExecStartPre=/bin/sh /home/pi/nyssIotBridgeBoot.sh
-ExecStart=/usr/local/bin/python3.6 /home/pi/smsEagle-iot-hub-handler.py
+ExecStart=/usr/bin/python3 /home/pi/smsEagle-iot-hub-handler.py
 
 [Install]
 WantedBy=multi-user.target

--- a/SMSEagleIOTBridge/nyss-iot-bridge.service
+++ b/SMSEagleIOTBridge/nyss-iot-bridge.service
@@ -9,8 +9,8 @@ Requires=network-online.target
 Type=simple
 Restart=always
 RestartSec=10
-ExecStartPre=/bin/sh -c 'until ping -c1 azure.microsoft.com; do sleep 5; done;'
-ExecStart=/usr/bin/python3 /home/pi/smsEagle-iot-hub-handler.py
+ExecStartPre=/bin/sh /home/pi/nyssIotBridgeBoot.sh
+ExecStart=/usr/local/bin/python3.6 /home/pi/smsEagle-iot-hub-handler.py
 
 [Install]
 WantedBy=multi-user.target

--- a/SMSEagleIOTBridge/nyssIotBridgeBoot.sh
+++ b/SMSEagleIOTBridge/nyssIotBridgeBoot.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+echo "Updating IoT Hub handler script"
+
+curl -s -o /home/pi/smsEagle-iot-hub-handler.py https://raw.githubusercontent.com/nyss-platform-norcross/nyss-sms-gateway/master/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
+res=$?
+if test "$res" != "0"
+then
+    echo "Failed to update IoT Hub handler script"
+else
+    chmod +x /home/pi/smsEagle-iot-hub-handler.py
+    echo "Successfully updated IoT Hub handler script"
+    # save script version as latest commit id
+    curl -s https://api.github.com/repos/nyss-platform-norcross/nyss-sms-gateway/commits | python3 -c "import sys, json; print(json.load(sys.stdin)[0]['sha'])" > /home/pi/iot-hub-handler-version.txt
+fi
+
+until ping -c1 azure.microsoft.com;
+do sleep 5;
+done;

--- a/SMSEagleIOTBridge/nyssIotBridgeBoot.sh
+++ b/SMSEagleIOTBridge/nyssIotBridgeBoot.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "Updating IoT Hub handler script"
 
-curl -s -o /home/pi/smsEagle-iot-hub-handler.py https://raw.githubusercontent.com/nyss-platform-norcross/nyss-sms-gateway/master/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
+curl -s -o /home/pi/smsEagle-iot-hub-handler.py https://raw.githubusercontent.com/nyss-platform-norcross/nyss-sms-gateway/feature/update-handler-script/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
 res=$?
 if test "$res" != "0"
 then
@@ -10,7 +10,7 @@ else
     chmod +x /home/pi/smsEagle-iot-hub-handler.py
     echo "Successfully updated IoT Hub handler script"
     # save script version as latest commit id
-    curl -s https://api.github.com/repos/nyss-platform-norcross/nyss-sms-gateway/commits | python3 -c "import sys, json; print(json.load(sys.stdin)[0]['sha'])" > /home/pi/iot-hub-handler-version.txt
+    curl -s https://api.github.com/repos/nyss-platform-norcross/nyss-sms-gateway/commits/feature/update-handler-script | python3 -c "import sys, json; print(json.load(sys.stdin)['sha'])" > /home/pi/iot-hub-handler-version.txt
 fi
 
 until ping -c1 azure.microsoft.com;

--- a/SMSEagleIOTBridge/nyssIotBridgeBoot.sh
+++ b/SMSEagleIOTBridge/nyssIotBridgeBoot.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "Updating IoT Hub handler script"
 
-curl -s -o /home/pi/smsEagle-iot-hub-handler.py https://raw.githubusercontent.com/nyss-platform-norcross/nyss-sms-gateway/feature/update-handler-script/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
+curl -s -o /home/pi/smsEagle-iot-hub-handler.py https://raw.githubusercontent.com/nyss-platform-norcross/nyss-sms-gateway/master/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
 res=$?
 if test "$res" != "0"
 then
@@ -10,7 +10,7 @@ else
     chmod +x /home/pi/smsEagle-iot-hub-handler.py
     echo "Successfully updated IoT Hub handler script"
     # save script version as latest commit id
-    curl -s https://api.github.com/repos/nyss-platform-norcross/nyss-sms-gateway/commits/feature/update-handler-script | python3 -c "import sys, json; print(json.load(sys.stdin)['sha'])" > /home/pi/iot-hub-handler-version.txt
+    curl -s https://api.github.com/repos/nyss-platform-norcross/nyss-sms-gateway/commits/master | python3 -c "import sys, json; print(json.load(sys.stdin)['sha'])" > /home/pi/iot-hub-handler-version.txt
 fi
 
 until ping -c1 azure.microsoft.com;

--- a/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
+++ b/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
@@ -5,6 +5,7 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 
 # Python 3 needs to be installed on the SMSEagle to start this script, using "do-not-use_apt-get"
 # do-not-use_apt-get update
@@ -19,7 +20,6 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S')
 
 logger = logging.getLogger("iot-hub-bridge")
-
 
 def get_sys_arg(i):
     return sys.argv[i] if i < len(sys.argv) else None
@@ -48,14 +48,23 @@ def send_sms(params):
 def ping_device(params):
     return "I am alive!"
 
+def handle_reboot():
+    time.sleep(5)
+    os.system('reboot')
 
 def reboot_device(params):
-    os.system('reboot')
-    return str("Rebooting in 1 minute.")
+    # handle reboot on a new thread in order to respond to azure before rebooting
+    reboot_thread = threading.Thread(target=handle_reboot)
+    reboot_thread.start()
+    return str("Device is rebooting.")
 
 
 def get_local_ips(params):
     return str(subprocess.getoutput('hostname -I'))
+
+def get_iot_hub_handler_version(params):
+    version = open('/home/pi/iot-hub-handler-version.txt', 'r')
+    return str(version)
 
 
 if __name__ == "__main__":
@@ -64,6 +73,7 @@ if __name__ == "__main__":
         'ping_device': ping_device,
         'reboot_device': reboot_device,
         'get_local_ips': get_local_ips,
+        'get_iot_hub_handler_version': get_iot_hub_handler_version
     }
 
     nyssIotBridge.init(IOT_HUB_CONNECTIONSTRING, methods)

--- a/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
+++ b/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
@@ -64,7 +64,7 @@ def get_local_ips(params):
 
 def get_iot_hub_handler_version(params):
     version = open('/home/pi/iot-hub-handler-version.txt', 'r')
-    return str(version)
+    return str(version.read())
 
 
 if __name__ == "__main__":

--- a/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
+++ b/SMSEagleIOTBridge/smsEagle-iot-hub-handler.py
@@ -64,7 +64,7 @@ def get_local_ips(params):
 
 def get_iot_hub_handler_version(params):
     version = open('/home/pi/iot-hub-handler-version.txt', 'r')
-    return str(version.read())
+    return str(version.read().replace('\n',''))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Add shell script to fetch latest version of the python script from github.
* Use ```ExecStartPre``` in the .service file to run the shell script before starting the service.
* Add direct method to get the version (commit id) of the python script.
* Update readme

The shell script fetches from the master branch, so to test you have to replace 'master' with 'feature/update-handler-script' in the urls